### PR TITLE
Feat formulario inicial

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,20 +9,28 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.2",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "5.4.2",
     "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "date-fns": "^2.30.0",
     "lucide-react": "^0.288.0",
     "next": "13.5.6",
     "next-auth": "^4.24.3",
     "prisma": "^5.4.2",
     "react": "^18",
+    "react-day-picker": "^8.9.1",
     "react-dom": "^18",
+    "react-hook-form": "^7.47.0",
     "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.5.6",

--- a/src/app/customer/page.tsx
+++ b/src/app/customer/page.tsx
@@ -1,0 +1,5 @@
+function CustomerPage() {
+  return <div>CustomerPage</div>;
+}
+
+export default CustomerPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import {Inter} from "next/font/google";
 
 import "./globals.css";
 import {NextAuthProvider} from "@/components/Providers/NextAuthProvider";
+import Navbar from "@/components/Navbar/Navbar";
 
 const inter = Inter({subsets: ["latin"]});
 
@@ -16,7 +17,10 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NextAuthProvider>{children}</NextAuthProvider>
+        <NextAuthProvider>
+          <Navbar />
+          <main className="">{children}</main>
+        </NextAuthProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,9 @@
-import Navbar from "@/components/Navbar/Navbar";
+import SearchForm from "@/components/SearchForm/SearchForm";
 
 export default function Home() {
   return (
-    <>
-      <Navbar />
-      <main className="" />
-    </>
+    <div className="min-h-[calc(100vh-5rem-1px)] flex items-center justify-center bg-slate-200">
+      <SearchForm className="flex items-center gap-2" />
+    </div>
   );
 }

--- a/src/components/DatePickerField/DatePickerField.tsx
+++ b/src/components/DatePickerField/DatePickerField.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable react/function-component-definition */
+import {format} from "date-fns";
+import {Calendar as CalendarIcon} from "lucide-react";
+
+import {cn} from "@/lib/utils/utils";
+
+import {Button} from "../ui/button";
+import {FormControl, FormField, FormItem, FormMessage} from "../ui/form";
+import {Popover, PopoverContent, PopoverTrigger} from "../ui/popover";
+import {Calendar} from "../ui/calendar";
+
+interface DatePickerFieldProps {
+  control: any;
+  name: string;
+}
+
+const DatePickerField: React.FC<DatePickerFieldProps> = ({control, name = ""}) => {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({field}) => (
+        <FormItem className="flex flex-col">
+          <Popover>
+            <PopoverTrigger asChild>
+              <FormControl>
+                <Button
+                  className={cn(
+                    "w-[240px] pl-3 text-left font-normal",
+                    !field.value && "text-muted-foreground",
+                  )}
+                  variant="outline"
+                >
+                  {field.value ? format(field.value, "PPP") : <span>Seleccionar Fecha</span>}
+                  <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                </Button>
+              </FormControl>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-auto p-0">
+              <Calendar
+                initialFocus
+                disabled={(date) => date > new Date() || date < new Date("1900-01-01")}
+                mode="single"
+                selected={field.value}
+                onSelect={field.onChange}
+              />
+            </PopoverContent>
+          </Popover>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+export default DatePickerField;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,16 +1,32 @@
+"use client";
+
 import Link from "next/link";
+import {useSession} from "next-auth/react";
 
 import SignInOutButtons from "../Buttons/SignInOutButtons";
+import {Button} from "../ui/button";
 
 function Navbar() {
+  const {data: session} = useSession();
+
   return (
-    <nav className="border p-2 shadow-sm">
+    <nav className="h-16 border p-2 shadow-sm">
       <ul className="flex items-center justify-between">
         <Link href="/">
           <p>DondeJugamos</p>
         </Link>
-
-        <SignInOutButtons />
+        <div className="mx-4 flex items-center gap-2">
+          <Link href="/customer">
+            <Button variant="secondary">Customer</Button>
+          </Link>
+          <Link href="/propietario">
+            <Button variant="secondary">Propietario</Button>
+          </Link>
+          <Link href="/admin">
+            <Button variant="secondary">Admin</Button>
+          </Link>
+          <SignInOutButtons />
+        </div>
       </ul>
     </nav>
   );

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable react/function-component-definition */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+"use client";
+
+import * as z from "zod";
+import {useForm} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+
+import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from "@/components/ui/form";
+
+import {Input} from "../ui/input";
+import {Button} from "../ui/button";
+import {DatePicker} from "../ui/datepicker";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "../ui/select";
+import DatePickerField from "../DatePickerField/DatePickerField";
+
+interface SearchFormProps {
+  className: string;
+}
+
+const formSchema = z.object({
+  location: z.string(),
+  sport: z.string(),
+  date: z.date(),
+  time: z.string(),
+});
+
+const SearchForm: React.FC<SearchFormProps> = ({className}) => {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      location: "",
+      sport: "",
+      date: new Date(),
+      time: "",
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    console.log(values);
+  };
+
+  return (
+    <Form {...form}>
+      <form className={`${className}`} onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="location"
+          render={({field}) => (
+            <FormItem>
+              {/* <FormLabel>Ciudad</FormLabel> */}
+              <FormControl>
+                <Input placeholder="Ciudad" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="sport"
+          render={({field}) => (
+            <FormItem>
+              {/* <FormLabel>Deporte</FormLabel> */}
+              <Select defaultValue={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Deportes" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="padel">Padel</SelectItem>
+                  <SelectItem value="futbol">Futbol</SelectItem>
+                  <SelectItem value="basquet">Basquet</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <DatePickerField control={form.control} name="date" />
+
+        <FormField
+          control={form.control}
+          name="time"
+          render={({field}) => (
+            <FormItem>
+              {/* <FormLabel>Hora Desde</FormLabel> */}
+              <Select defaultValue={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Hora Desde" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="16:00">16:00 hs</SelectItem>
+                  <SelectItem value="17:00">17:00 hs</SelectItem>
+                  <SelectItem value="18:00">18:00 hs</SelectItem>
+                  <SelectItem value="19:00">19:00 hs</SelectItem>
+                  <SelectItem value="20:00">20:00 hs</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default SearchForm;

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import {ChevronLeft, ChevronRight} from "lucide-react";
+import {DayPicker} from "react-day-picker";
+
+import {buttonVariants} from "@/components/ui/button";
+import {cn} from "@/lib/utils/utils";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({className, classNames, showOutsideDays = true, ...props}: CalendarProps) {
+  return (
+    <DayPicker
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: cn(
+          buttonVariants({variant: "outline"}),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day: cn(
+          buttonVariants({variant: "ghost"}),
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+        ),
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside: "text-muted-foreground opacity-50",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        // eslint-disable-next-line react/no-unstable-nested-components, @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
+        IconLeft: ({...props}) => <ChevronLeft className="h-4 w-4" />,
+        // eslint-disable-next-line react/no-unstable-nested-components, @typescript-eslint/no-unused-vars, @typescript-eslint/no-shadow
+        IconRight: ({...props}) => <ChevronRight className="h-4 w-4" />,
+      }}
+      showOutsideDays={showOutsideDays}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = "Calendar";
+
+export {Calendar};

--- a/src/components/ui/datepicker.tsx
+++ b/src/components/ui/datepicker.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+import {format} from "date-fns";
+import {Calendar as CalendarIcon} from "lucide-react";
+
+import {Button} from "@/components/ui/button";
+import {Calendar} from "@/components/ui/calendar";
+import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
+import {cn} from "@/lib/utils/utils";
+
+export function DatePicker() {
+  const [date, setDate] = React.useState<Date>();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          className={cn(
+            "w-[280px] justify-start text-left font-normal",
+            !date && "text-muted-foreground",
+          )}
+          variant="outline"
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {date ? format(date, "PPP") : <span>Pick a date</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0">
+        <Calendar initialFocus mode="single" selected={date} onSelect={setDate} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,170 @@
+import type * as LabelPrimitive from "@radix-ui/react-label";
+import type {ControllerProps, FieldPath, FieldValues} from "react-hook-form";
+
+import * as React from "react";
+import {Slot} from "@radix-ui/react-slot";
+import {Controller, FormProvider, useFormContext} from "react-hook-form";
+
+import {cn} from "@/lib/utils/utils";
+import {Label} from "@/components/ui/label";
+
+const Form = FormProvider;
+
+{
+  /*eslint-disable-next-line @typescript-eslint/consistent-type-definitions*/
+}
+interface FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  name: TName;
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({...props}: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{name: props.name}}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const {getFieldState, formState} = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  // eslint-disable-next-line prettier/prettier
+  {    /*eslint-disable-next-line @typescript-eslint/no-unnecessary-condition*/  }
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const {id} = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+interface FormItemContextValue {
+  id: string;
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({className, ...props}, ref) => {
+    const id = React.useId();
+
+    return (
+      <FormItemContext.Provider value={{id}}>
+        <div ref={ref} className={cn(className)} {...props} />
+      </FormItemContext.Provider>
+    );
+  },
+);
+
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({className, ...props}, ref) => {
+  const {error, formItemId} = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({...props}, ref) => {
+  const {error, formItemId, formDescriptionId, formMessageId} = useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+      aria-invalid={!!error}
+      id={formItemId}
+      {...props}
+    />
+  );
+});
+
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({className, ...props}, ref) => {
+  const {formDescriptionId} = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      id={formDescriptionId}
+      {...props}
+    />
+  );
+});
+
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({className, children, ...props}, ref) => {
+  const {error, formMessageId} = useFormField();
+  const body = error ? String(error.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      className={cn("text-sm font-medium text-destructive", className)}
+      id={formMessageId}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+
+FormMessage.displayName = "FormMessage";
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import {cn} from "@/lib/utils/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({className, type, ...props}, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      type={type}
+      {...props}
+    />
+  );
+});
+
+Input.displayName = "Input";
+
+export {Input};

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import {cva, type VariantProps} from "class-variance-authority";
+
+import {cn} from "@/lib/utils/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({className, ...props}, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export {Label};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import {cn} from "@/lib/utils/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({className, align = "center", sideOffset = 4, ...props}, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export {Popover, PopoverTrigger, PopoverContent};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import {Check, ChevronDown} from "lucide-react";
+
+import {cn} from "@/lib/utils/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({className, children, ...props}, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({className, children, position = "popper", ...props}, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({className, ...props}, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({className, children, ...props}, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({className, ...props}, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+};


### PR DESCRIPTION
### #10: Feat Formulario Inicial

La idea era avanzar con un formulario básico para obtener los establecimientos con turnos disponibles bajo ciertos criterios de búsqueda, que le pegue a la API y muestre los resultados por pantalla. Todo de una manera simple y sin mucho despliegue técnico.

El criterio de búsqueda toma en cuenta lo siguiente:
- Ubicación (location)
- Deporte (sport)
- Fecha (date)
- Hora desde (startTime)

### 1° commit: Componentes Librería shadcn

Se agregaron los componentes necesarios para realizar el formulario con los criterios de búsqueda mencionados anteriormente. Listado de componentes: _input, label, calendar, popover, datepicker, select, form_.
Para el _DatePicker_ se tuvo que realizar un Componente a parte (**DatePickerField**) por la complejidad de insertarlo a un Formulario. (Capaz me mezcle mucho y no era necesario).

**Se actualizó el package.json.**

### 2° commit: Formulario en Home y Acceso a los tipos de usuarios

Se creo el componente **SearchForm** el cual funciona por ahora como una barra de búsqueda, donde tiene los distintos inputs para los criterios de búsqueda.

También se agregó como para verificar el funcionamiento, un acceso a las distintas páginas de los usuarios para verificar el funcionamiento y tener un fácil acceso de los mismos de momento. Esto luego va a desaparecer.


**Quedo pendiente lo de hace pegarle a la API y mostrar el resultado** 
