### PR TITLE
Feat mejoras cancha turnos

### DIFF
--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/components/ScheduleForm.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/components/ScheduleForm.tsx
@@ -3,22 +3,23 @@
 /* eslint-disable react/function-component-definition */
 import type {FC} from "react";
 import type {Dayjs} from "dayjs";
-import type {CourtSchedule} from "@/lib/types/importables/types";
+import type {ApiResponse, CourtSchedule} from "@/lib/types/importables/types";
+import type {CourtFullInfo} from "@/backend/db/models/courts";
 
 import dayjs from "dayjs";
 import React, {useState} from "react";
 import {useRouter} from "next/navigation";
+import {Clock3Icon} from "lucide-react";
 
 import {timeToMinutesDayJs} from "@/lib/utils/utils";
 import TimePickerUI from "@/components/TimePicker/time-picker";
 import {Button} from "@/components/ui/button";
 import {ToggleGroup, ToggleGroupItem} from "@/components/ui/toggle-group";
+import {errorToast, successToast} from "@/lib/utils/toasts";
 
 import {DAYS_OF_WEEK} from "../horarios/page";
 
 import ScheduleTable from "./ScheduleTable";
-import { CourtFullInfo } from "@/backend/db/models/courts";
-import { Clock3Icon } from "lucide-react";
 
 interface HorarioFormProps {
   schedule: CourtSchedule[];
@@ -69,77 +70,83 @@ const ScheduleForm: FC<HorarioFormProps> = ({courtId, courts, schedule, court}) 
       body: JSON.stringify({days, courts}),
     });
 
-    const data = await response.json();
+    const data = (await response.json()) as ApiResponse;
 
-    router.push(`../${courtId}`);
+    if (data.status === 200) {
+      successToast("Se actualizaron los horarios correctamente");
+      router.refresh();
+      router.push(`../${courtId}`);
+    } else {
+      errorToast("No se puedieron actualizar los horarios");
+      router.push(`../${courtId}`);
+    }
   };
 
   return (
     <div className="container max-w-5xl mx-auto p-8">
-        <h3 className="w-full mb-4 bg-primary text-white p-2 flex items-center gap-2 text-xl">
-            <Clock3Icon /> Horarios - {court?.name}
-          </h3>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <span className="font-medium text-lg my-2">Dias de la semana</span>
-            <ToggleGroup type="multiple" variant="outline" onValueChange={setSelectedDays}>
-              <div>
-                {days.map((option, index) => (
-                  <ToggleGroupItem
-                    key={index}
-                    aria-label={`Toggle ${option.name}`}
-                    className="data-[state=on]:bg-green-600 data-[state=on]:text-white"
-                    disabled={option.openTime != null || option.closeTime != null}
-                    value={option.name}
-                  >
-                    {DAYS_OF_WEEK[`${option.name}`].name}
-                  </ToggleGroupItem>
-                ))}
-              </div>
-            </ToggleGroup>
+      <h3 className="w-full mb-4 bg-primary text-white p-2 flex items-center gap-2 text-xl">
+        <Clock3Icon /> Horarios - {court?.name}
+      </h3>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <span className="font-medium text-lg my-2">Dias de la semana</span>
+          <ToggleGroup type="multiple" variant="outline" onValueChange={setSelectedDays}>
+            <div>
+              {days.map((option, index) => (
+                <ToggleGroupItem
+                  key={index}
+                  aria-label={`Toggle ${option.name}`}
+                  className="data-[state=on]:bg-green-600 data-[state=on]:text-white"
+                  disabled={option.openTime != null || option.closeTime != null}
+                  value={option.name}
+                >
+                  {DAYS_OF_WEEK[`${option.name}`].name}
+                </ToggleGroupItem>
+              ))}
+            </div>
+          </ToggleGroup>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="flex-auto flex flex-col gap-2">
+            <span className="font-medium text-lg">Horario de Apertura</span>
+            <TimePickerUI
+              ampm={false}
+              className="w-full"
+              value={openTime}
+              onChange={(value: Dayjs) => {
+                setOpenTime(value);
+              }}
+            />
           </div>
 
-          <div className="flex items-center gap-4">
-            <div className="flex-auto flex flex-col gap-2">
-              <span className="font-medium text-lg">Horario de Apertura</span>
-              <TimePickerUI
-                ampm={false}
-                className="w-full"
-                value={openTime}
-                onChange={(value: Dayjs) => {
-                  setOpenTime(value);
-                }}
-              />
-            </div>
-
-            <div className="flex-auto flex flex-col gap-2">
-              <span className="font-medium text-lg">Horario de Cierre</span>
-                <TimePickerUI
-                  ampm={false}
-                  className="w-full"
-                  value={closeTime}
-                  onChange={(value: Dayjs) => {
-                    setCloseTime(value);
-                  }}
-                />
-            </div>
+          <div className="flex-auto flex flex-col gap-2">
+            <span className="font-medium text-lg">Horario de Cierre</span>
+            <TimePickerUI
+              ampm={false}
+              className="w-full"
+              value={closeTime}
+              onChange={(value: Dayjs) => {
+                setCloseTime(value);
+              }}
+            />
           </div>
-          
-          <Button
-            className="bg-blue-500 text-white hover:bg-blue-300"
-            variant="secondary"
-            onClick={handleClic}
-          >
-            Agregar Horario
-          </Button>
+        </div>
 
-          <div>
+        <Button
+          className="bg-blue-500 text-white hover:bg-blue-300"
+          variant="secondary"
+          onClick={handleClic}
+        >
+          Agregar Horario
+        </Button>
+
+        <div>
           <ScheduleTable showHeader handleEdit={handleEdit} schedule={days} />
         </div>
-          
-          <Button onClick={updateCourtTimes}>Finalizar</Button>
-        </div>
-      
+
+        <Button onClick={updateCourtTimes}>Finalizar</Button>
+      </div>
     </div>
   );
 };

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentDay.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentDay.tsx
@@ -1,24 +1,27 @@
-/* eslint-disable react/function-component-definition */
-import type {Appointment} from "@prisma/client";
-import type {FC} from "react";
+import type {AppointmentViewSchedule} from "../../page";
 
-import {timeInStringFromMinutes} from "@/lib/utils/utils";
+import {cn, timeInStringFromMinutes} from "@/lib/utils/utils";
 
 interface AppointmentDayProps {
-  appointment: Omit<Appointment, "id" | "date" | "courtId">;
+  appointment: AppointmentViewSchedule;
 }
 
-const AppointmentDay: FC<AppointmentDayProps> = ({appointment}) => {
+export default function AppointmentDay({appointment}: AppointmentDayProps) {
+  const color = !appointment.active
+    ? "bg-neutral-400/40"
+    : appointment.reservationState === "approved"
+    ? "bg-blue-400/40"
+    : appointment.reservationState === "pending"
+    ? "bg-yellow-400/40"
+    : "bg-green-400/40";
+
   return (
     <div
       key={appointment.startTime + appointment.endTime}
-      className={`w-auto p-1 border flex rounded-md select-none 
-            ${appointment.active ? "bg-green-400/40" : "bg-neutral-400/40"} `}
+      className={cn(`w-auto p-1 border flex rounded-md select-none`, color)}
     >
       <span>{timeInStringFromMinutes(appointment.startTime.toString())}</span>-
       <span>{timeInStringFromMinutes(appointment.endTime.toString())}</span>
     </div>
   );
-};
-
-export default AppointmentDay;
+}

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentEdit.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentEdit.tsx
@@ -37,9 +37,16 @@ const AppointmentEdit: FC<AppointmentEditProps> = ({appointments, courtId}) => {
   const handleAppointmentChangeState = (
     day: number,
     appointmentsChanged: Partial<Appointment>[],
+    update = false,
   ) => {
     appointments[day] = appointmentsChanged;
     setAppointmentsUpdated({...appointments});
+
+    if (update) {
+      appointmentsChanged.forEach((app) => {
+        handleAppointmentChange(app);
+      });
+    }
   };
 
   const saveChanges = () => {
@@ -50,6 +57,7 @@ const AppointmentEdit: FC<AppointmentEditProps> = ({appointments, courtId}) => {
       .then((res: ApiResponse) => {
         if (res.status === 200) {
           successToast("Los turnos se modificaron con exito!");
+          router.refresh();
           router.push(`../../${courtId}`);
         } else throw Error(res.message);
       })
@@ -74,7 +82,9 @@ const AppointmentEdit: FC<AppointmentEditProps> = ({appointments, courtId}) => {
           />
         ))}
       </div>
-      <Button className="block w-40 mx-auto" onClick={saveChanges}>Guardar</Button>
+      <Button className="block w-40 mx-auto" onClick={saveChanges}>
+        Guardar
+      </Button>
     </div>
   );
 };

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentsDayList.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/AppointmentsDayList.tsx
@@ -15,7 +15,7 @@ interface AppointmentsDayListProps {
   date: number;
   appointments: Partial<Appointment>[];
   editable?: boolean;
-  updateState?: (day: number, appointments: Partial<Appointment>[]) => void;
+  updateState?: (day: number, appointments: Partial<Appointment>[], update?: boolean) => void;
   updateAppointment?: (appointment: Partial<Appointment>) => void;
 }
 
@@ -52,11 +52,34 @@ const AppointmentsDayList: FC<AppointmentsDayListProps> = ({
     }
   };
 
+  const enableAll = () => {
+    appointments.forEach((app) => (app.active = true));
+
+    if (updateState) {
+      updateState(date, [...appointments], true);
+    }
+  };
+
+  const disableAll = () => {
+    appointments.forEach((app) => (app.active = false));
+    if (updateState) {
+      updateState(date, [...appointments], true);
+    }
+  };
+
   return (
     <div className="rounded-md">
       <header className="p-2 flex items-center gap-4">
         <div className="text-xl font-medium">
           {dayStr} de {monthStr}
+        </div>
+        <div className="flex gap-1 ml-auto">
+          <button className="p-2 text-xs text-white bg-blue-400 rounded-md" onClick={enableAll}>
+            Habilitar Todos
+          </button>
+          <button className="p-2 text-xs text-white bg-neutral-500 rounded-md" onClick={disableAll}>
+            Deshabilitar Todos
+          </button>
         </div>
       </header>
 

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/GenerateAppointmentsClient.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/components/GenerateAppointmentsClient.tsx
@@ -85,6 +85,7 @@ const GenerateAppointmentsClient: FC<GenerateAppointmentsClientProps> = ({
       .then((res: ApiResponse) => {
         if (res.status === 200) {
           successToast("Los turnos se generaron con exito!");
+          router.refresh();
           router.push(`../${courtId}`);
         } else throw Error(res.message);
       })
@@ -95,7 +96,6 @@ const GenerateAppointmentsClient: FC<GenerateAppointmentsClientProps> = ({
 
   return (
     <div className="container mx-auto mt-8">
-      
       <div className="w-fit mx-auto">
         <p className="text-lg font-medium">
           Seleccione el rango de fechas en el que quiera generar los turnos
@@ -128,7 +128,11 @@ const GenerateAppointmentsClient: FC<GenerateAppointmentsClientProps> = ({
           <Button className="flex-auto" onClick={handleGenerate}>
             Generar
           </Button>
-          <Button className="flex-auto bg-blue-500" disabled={dates.length == 0} onClick={saveAppointments}>
+          <Button
+            className="flex-auto bg-blue-500"
+            disabled={dates.length == 0}
+            onClick={saveAppointments}
+          >
             Finalizar
           </Button>
         </div>

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/modificar/page.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/canchas/[courtId]/turnos/modificar/page.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import type {Appointment} from "@prisma/client";
 
-import {getAllAppointments} from "@/backend/db/models/appointments";
+import {getAllCourtAppointments} from "@/backend/db/models/appointments";
 
 import AppointmentEdit from "../components/AppointmentEdit";
 
 /* eslint-disable react/function-component-definition */
 const ModificarTurnoPage = async ({params}: {params: {sportCenterId: string; courtId: string}}) => {
-  const appointmentsPersisted = await getAllAppointments();
+  const appointmentsPersisted = await getAllCourtAppointments(Number(params.courtId));
   const appointments: Record<number, Appointment[]> = {};
 
   if (!appointmentsPersisted.length) {

--- a/src/app/(propietario)/establecimientos/[sportCenterId]/page.tsx
+++ b/src/app/(propietario)/establecimientos/[sportCenterId]/page.tsx
@@ -5,7 +5,6 @@ import {buttonVariants} from "@/components/ui/button";
 import {getSportCenterByIdWithReservations} from "@/backend/db/models/sportsCenters";
 import {CountReservationsByState, turnStateToSpanish} from "@/lib/utils/utils";
 import {getSportCenterReservations} from "@/backend/db/models/reservations";
-import SportCenterClient from "@/components/SportCenterForm/SportCenterFormClient";
 import ReservationCard from "@/components/Reservation/Propietary/ReservationCard";
 
 async function EstablecimientosPage({

--- a/src/app/api/appointment/route.ts
+++ b/src/app/api/appointment/route.ts
@@ -74,7 +74,7 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
-export async function post(request: NextRequest) {
+export async function POST(request: NextRequest) {
   const formData = await request.formData();
 
   const observation = formData.get("observation") as string;

--- a/src/app/api/court/route.ts
+++ b/src/app/api/court/route.ts
@@ -20,8 +20,6 @@ export async function POST(request: NextRequest) {
     "Se actualizaron los horarios de la cancha correctamente",
   );
 
-  console.log("Se esta por guardar", days);
-
   for (const court of courts) {
     for (const day of days) {
       daysToCreate.push(

--- a/src/backend/db/models/appointments.ts
+++ b/src/backend/db/models/appointments.ts
@@ -23,6 +23,16 @@ export type AppointmentWithCourtAndSportcenter = Prisma.AppointmentGetPayload<{
   };
 }>;
 
+export type AppointmentReservation = Prisma.AppointmentGetPayload<{
+  include: {
+    reservations: {
+      select: {
+        state: true;
+      };
+    };
+  };
+}>;
+
 export const getAppointmentFullInformation = async (
   id: number,
 ): Promise<AppointmentWithCourtAndSportcenter | null> => {
@@ -168,7 +178,7 @@ export const deleteAppointments = async (
   }
 };
 
-export const getAllAppointments = async () => {
+export const getAllCourtAppointments = async (courtId: number) => {
   const currentDate = new Date();
 
   currentDate.setHours(0, 0, 0, 0);
@@ -177,6 +187,7 @@ export const getAllAppointments = async () => {
       date: {
         gte: currentDate,
       },
+      courtId: courtId,
     },
   });
 

--- a/src/backend/db/models/courts.ts
+++ b/src/backend/db/models/courts.ts
@@ -24,6 +24,33 @@ export type CourtFullInfo = Prisma.CourtGetPayload<{
   };
 }>;
 
+export type CourtComplete = Prisma.CourtGetPayload<{
+  include: {
+    sport: {
+      select: {
+        id: true;
+        name: true;
+        duration: true;
+      };
+    };
+    days: true;
+    sportCenter: {
+      select: {
+        name: true;
+      };
+    };
+    appointments: {
+      include: {
+        reservations: {
+          select: {
+            state: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
 export type CourtWithDays = Prisma.CourtGetPayload<{
   include: {
     days: true;
@@ -91,12 +118,18 @@ export const getFullCourtById = async (courtId: number): Promise<CourtFullInfo |
 export const findWithDays = async (
   sportCenterId: string | number,
   courtId: string | number,
-): Promise<CourtFullInfo | null> => {
+): Promise<CourtComplete | null> => {
   const currentDate = new Date();
+  const tomorrowDate = new Date();
   const limitDate = new Date();
+  const currentTime = currentDate.getHours() * 60 + currentDate.getMinutes();
+
+  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+  limitDate.setDate(limitDate.getDate() + 3);
 
   currentDate.setHours(0, 0, 0, 0);
-  limitDate.setDate(limitDate.getDate() + 10);
+  tomorrowDate.setHours(0, 0, 0, 0);
+  limitDate.setHours(23, 59, 59, 999);
 
   return await db.court.findUnique({
     where: {
@@ -118,11 +151,44 @@ export const findWithDays = async (
         },
       },
       appointments: {
-        where: {
-          date: {
-            gte: currentDate,
-            lte: limitDate,
+        include: {
+          reservations: {
+            select: {
+              state: true,
+            },
+            where: {
+              OR: [
+                {
+                  state: "pending",
+                },
+                {
+                  state: "approved",
+                },
+              ],
+            },
+            orderBy: {
+              date: "desc",
+            },
+            take: 1,
           },
+        },
+        where: {
+          OR: [
+            {
+              date: {
+                equals: currentDate,
+              },
+              startTime: {
+                gte: currentTime,
+              },
+            },
+            {
+              date: {
+                gte: tomorrowDate,
+                lte: limitDate,
+              },
+            },
+          ],
         },
       },
     },
@@ -146,7 +212,7 @@ export const lastAppointmentDate = async (courtId: string | number): Promise<Dat
     });
 
     if (result) {
-      const maxDate = result._max.date ?  new Date(result._max.date) : new Date();
+      const maxDate = result._max.date ? new Date(result._max.date) : new Date();
 
       return maxDate; // Devuelve la fecha obtenida como un objeto Date
     } else {


### PR DESCRIPTION

### Commit 1 y 2.
Los primeros 2 commits de la PR son mas de limpieza de logs, algunos arreglos pavos y lo mas importante, que al generar los horarios o turnos se actualice automáticamente la pantalla principal de la cancha con las modificaciones realizadas.

### Commit 3
Se agrego la opción de habilitar o deshabilitar los turnos en la pantalla de editar turnos, agregando unos botones, para que no se tenga que estar clickeando uno por uno en el caso de que se quiera deshabilitar un día completo.

### Commit 4
Se hizo la modificación a la query utilizada en la pantalla principal de la cancha para que los turnos reaccionen a: 

- Turno inactivo _(color: gris)_
- Si tiene reserva, estado igual a **approved** _(color: azul)_
- Si tiene reserva, estado igual a **pending** _(color: amarrillo)_
- Turno activo o si no tiene reservas _(color: verde)_

_NOTA: en la query se obtiene el estado de la última ordenada por fecha en orden descendiente_